### PR TITLE
Add compatibility for the mod Lootr, simplify loot table setting.

### DIFF
--- a/src/main/java/com/catastrophe573/dimdungeons/feature/AdvancedDungeonFeature.java
+++ b/src/main/java/com/catastrophe573/dimdungeons/feature/AdvancedDungeonFeature.java
@@ -29,10 +29,7 @@ import net.minecraft.potion.EffectInstance;
 import net.minecraft.potion.Effects;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.state.properties.StructureMode;
-import net.minecraft.tileentity.BarrelTileEntity;
-import net.minecraft.tileentity.ChestTileEntity;
-import net.minecraft.tileentity.DispenserTileEntity;
-import net.minecraft.tileentity.TileEntity;
+import net.minecraft.tileentity.*;
 import net.minecraft.util.Mirror;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.Rotation;
@@ -323,12 +320,7 @@ public class AdvancedDungeonFeature extends Feature<NoFeatureConfig>
 	else if ("SetTrappedLoot".equals(name))
 	{
 	    world.setBlockState(pos, Blocks.AIR.getDefaultState(), 2); // erase this data block
-	    ChestTileEntity te = (ChestTileEntity) world.getTileEntity(pos.down());
-	    if (te != null)
-	    {
-		te.clear();
-		te.setLootTable(new ResourceLocation(DimDungeons.RESOURCE_PREFIX + "chests/chestloot_3"), rand.nextLong());
-	    }
+	    LockableLootTileEntity.setLootTable(world, rand, pos, new ResourceLocation(DimDungeons.RESOURCE_PREFIX + "chests/chestloot_3"));
 	}
 	else if ("BarrelLoot1".equals(name))
 	{
@@ -553,13 +545,8 @@ public class AdvancedDungeonFeature extends Feature<NoFeatureConfig>
 	faceContainerTowardsAir(world, pos.down());
 
 	// set the loot table
-	TileEntity te = world.getTileEntity(pos.down());
-	if (te instanceof ChestTileEntity)
-	{
-	    ((ChestTileEntity) te).clear();
-	    ((ChestTileEntity) te).setLootTable(lootTable, rand.nextLong());
-	}
-	else
+	LockableLootTileEntity.setLootTable(world, rand, pos, lootTable);
+	if (!(world.getTileEntity(pos) instanceof ChestTileEntity))
 	{
 	    DimDungeons.LOGGER.info("DIMDUNGEONS: FAILED TO PLACE CHEST IN DUNGEON. pos = " + pos.getX() + ", " + pos.getZ());
 	}
@@ -570,13 +557,8 @@ public class AdvancedDungeonFeature extends Feature<NoFeatureConfig>
 	world.setBlockState(pos, Blocks.AIR.getDefaultState(), 2); // erase this data block
 
 	// set the loot table
-	TileEntity te = world.getTileEntity(pos.down());
-	if (te instanceof BarrelTileEntity)
-	{
-	    ((BarrelTileEntity) te).clear();
-	    ((BarrelTileEntity) te).setLootTable(lootTable, rand.nextLong());
-	}
-	else
+	LockableLootTileEntity.setLootTable(world, rand, pos, lootTable);
+	if (!(world.getTileEntity(pos) instanceof BarrelTileEntity))
 	{
 	    DimDungeons.LOGGER.info("DIMDUNGEONS: FAILED TO PLACE BARREL IN DUNGEON. pos = " + pos.getX() + ", " + pos.getZ());
 	}

--- a/src/main/java/com/catastrophe573/dimdungeons/feature/BasicDungeonFeature.java
+++ b/src/main/java/com/catastrophe573/dimdungeons/feature/BasicDungeonFeature.java
@@ -26,10 +26,7 @@ import net.minecraft.nbt.ListNBT;
 import net.minecraft.nbt.StringNBT;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.state.properties.StructureMode;
-import net.minecraft.tileentity.BarrelTileEntity;
-import net.minecraft.tileentity.ChestTileEntity;
-import net.minecraft.tileentity.DispenserTileEntity;
-import net.minecraft.tileentity.TileEntity;
+import net.minecraft.tileentity.*;
 import net.minecraft.util.Mirror;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.Rotation;
@@ -441,12 +438,7 @@ public class BasicDungeonFeature extends Feature<NoFeatureConfig>
 	else if ("SetTrappedLoot".equals(name))
 	{
 	    world.setBlockState(pos, Blocks.AIR.getDefaultState(), 2); // erase this data block
-	    ChestTileEntity te = (ChestTileEntity) world.getTileEntity(pos.down());
-	    if (te != null)
-	    {
-		te.clear();
-		te.setLootTable(new ResourceLocation(DimDungeons.RESOURCE_PREFIX + "chests/chestloot_1"), rand.nextLong());
-	    }
+	    LockableLootTileEntity.setLootTable(world, rand, pos, new ResourceLocation(DimDungeons.RESOURCE_PREFIX + "chests/chestloot_1"));
 	}
 	else if ("BarrelLoot1".equals(name))
 	{
@@ -631,13 +623,8 @@ public class BasicDungeonFeature extends Feature<NoFeatureConfig>
 	faceContainerTowardsAir(world, pos.down());
 
 	// set the loot table
-	TileEntity te = world.getTileEntity(pos.down());
-	if (te instanceof ChestTileEntity)
-	{
-	    ((ChestTileEntity) te).clear();
-	    ((ChestTileEntity) te).setLootTable(lootTable, rand.nextLong());
-	}
-	else
+	LockableLootTileEntity.setLootTable(world, rand, pos, lootTable);
+	if (!(world.getTileEntity(pos) instanceof ChestTileEntity))
 	{
 	    DimDungeons.LOGGER.info("DIMDUNGEONS: FAILED TO PLACE CHEST IN DUNGEON. pos = " + pos.getX() + ", " + pos.getZ());
 	}
@@ -648,13 +635,8 @@ public class BasicDungeonFeature extends Feature<NoFeatureConfig>
 	world.setBlockState(pos, Blocks.AIR.getDefaultState(), 2); // erase this data block
 
 	// set the loot table
-	TileEntity te = world.getTileEntity(pos.down());
-	if (te instanceof BarrelTileEntity)
-	{
-	    ((BarrelTileEntity) te).clear();
-	    ((BarrelTileEntity) te).setLootTable(lootTable, rand.nextLong());
-	}
-	else
+	LockableLootTileEntity.setLootTable(world, rand, pos, lootTable);
+	if (!(world.getTileEntity(pos) instanceof BarrelTileEntity))
 	{
 	    DimDungeons.LOGGER.info("DIMDUNGEONS: FAILED TO PLACE BARREL IN DUNGEON. pos = " + pos.getX() + ", " + pos.getZ());
 	}


### PR DESCRIPTION
Using the `setLootTable` member method of a tile entity prevents the mod Lootr, which replaces loot chests with a chest that creates an inventory for each player that opens it (making it possible for multiple people to loot the same chest and all get loot), from being able to hook in.

While a hook can be made into the tile entity, generally the point at which the `setLootTable` call is made is using the `IWorld` instance of chunk generation, which isn't the same as the `world` found in the tile entity (if it even has one).

Conversely, using `LockableLootTileEntity.setLootTable` provides the chunk generation world and serves as a convenient point for injection. It otherwise replicates the functionality as you had it: fetching the tile entity, calling the function and setting a random seed.

Where you also had error testing, I added an additional test that would trigger your debugging message instead.

Lootr currently supports all vanilla loot chests, including the ones that are really annoying, and uses a structure processor to convert all structure NBT files as they're loaded from disk.

Previous attempts to use a tile tracker and determine if a chunk was ready for external modification (i.e., generation was complete) proved ineffectual and while some aspects worked well, there were too many concurrent modification errors in 1.15.

Finally, I'm not sure if I've got the formatting right, but there doesn't seem to be a huge consistency to the formatting so I tried to just match what was around.

My only constructive criticism would be that there's a lot of repetitive functions -- you have two "fillChestBelow" and "fillBarrelBelow" functions with almost identical code that could just be static methods.